### PR TITLE
Add support for msvc version 1929

### DIFF
--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -105,10 +105,17 @@ cmake_minimum_required(VERSION 3.5)
 # Global variables used only in this script (unset at the end)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
-set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1930
-                                    1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
-                                    1916 1915 1914 1913 1912 1911 1910 1900
-                                    1800 1700 1600 1500 1400)
+set(_Vcvars_SUPPORTED_MSVC_VERSIONS
+  1930 # VS 2022
+  1929 1928 1927 1926 1925 1924 1923 1922 1921 1920 # VS 2019
+  1916 1915 1914 1913 1912 1911 1910 # VS 2017
+  1900 # VS 2015
+  1800 # VS 2013
+  1700 # VS 2012
+  1600 # VS 2010
+  1500 # VS 2008
+  1400 # VS 2005
+  )
 
 function(_vcvars_message)
   if(NOT Vcvars_FIND_QUIETLY)

--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -105,7 +105,8 @@ cmake_minimum_required(VERSION 3.5)
 # Global variables used only in this script (unset at the end)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
-set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
+set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1930
+                                    1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
                                     1916 1915 1914 1913 1912 1911 1910 1900
                                     1800 1700 1600 1500 1400)
 
@@ -120,7 +121,9 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930))     # VS 2019
+  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1940))     # VS 2022
+    set(vs_version "17")
+  elseif((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
     set(vs_version "16")
   elseif((msvc_version GREATER_EQUAL 1910) AND (msvc_version LESS 1920)) # VS 2017
     set(vs_version "15")

--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -105,7 +105,7 @@ cmake_minimum_required(VERSION 3.5)
 # Global variables used only in this script (unset at the end)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
-set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1928 1927 1926 1925 1924 1923 1922 1921 1920
+set(_Vcvars_SUPPORTED_MSVC_VERSIONS 1929 1928 1927 1926 1925 1924 1923 1922 1921 1920
                                     1916 1915 1914 1913 1912 1911 1910 1900
                                     1800 1700 1600 1500 1400)
 
@@ -120,38 +120,10 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if(msvc_version EQUAL 1928)     # VS 2019
-    set(vs_version "16.8")
-  elseif(msvc_version EQUAL 1927) # VS 2019
-    set(vs_version "16.7")
-  elseif(msvc_version EQUAL 1926) # VS 2019
-    set(vs_version "16.6")
-  elseif(msvc_version EQUAL 1925) # VS 2019
-    set(vs_version "16.5")
-  elseif(msvc_version EQUAL 1924) # VS 2019
-    set(vs_version "16.4")
-  elseif(msvc_version EQUAL 1923) # VS 2019
-    set(vs_version "16.3")
-  elseif(msvc_version EQUAL 1922) # VS 2019
-    set(vs_version "16.2")
-  elseif(msvc_version EQUAL 1921) # VS 2019
-    set(vs_version "16.1")
-  elseif(msvc_version EQUAL 1920) # VS 2019
-    set(vs_version "16.0")
-  elseif(msvc_version EQUAL 1916) # VS 2017
-    set(vs_version "15.9")
-  elseif(msvc_version EQUAL 1915) # VS 2017
-    set(vs_version "15.8")
-  elseif(msvc_version EQUAL 1914) # VS 2017
-    set(vs_version "15.7")
-  elseif(msvc_version EQUAL 1913) # VS 2017
-    set(vs_version "15.6")
-  elseif(msvc_version EQUAL 1912) # VS 2017
-    set(vs_version "15.5")
-  elseif(msvc_version EQUAL 1911) # VS 2017
-    set(vs_version "15.3")
-  elseif(msvc_version EQUAL 1910) # VS 2017
-    set(vs_version "15.0")
+  if((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930))     # VS 2019
+    set(vs_version "16")
+  elseif((msvc_version GREATER_EQUAL 1910) AND (msvc_version LESS 1920)) # VS 2017
+    set(vs_version "15")
   elseif(msvc_version EQUAL 1900) # VS 2015
     set(vs_version "14.0")
   elseif(msvc_version EQUAL 1800) # VS 2013


### PR DESCRIPTION
Changes were made to setting vs_version based on recent patterns. VS Version 16.8 and 16.9 both correspond to 1928. VS Version 16.10 and 16.11 both correspond to 1929.

Also added initial support for Visual Studio 2022.