### PR TITLE
Add support for msvc version 1940 (Visual Studio 2022) and anticipate future releases up to 1950

### DIFF
--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -104,7 +104,7 @@ cmake_minimum_required(VERSION 3.5)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
 set(_Vcvars_SUPPORTED_MSVC_VERSIONS
-  1939 1938 1937 1936 1935 1934 1933 1932 1931 1930 # VS 2022
+  1940 1939 1938 1937 1936 1935 1934 1933 1932 1931 1930 # VS 2022
   1929 1928 1927 1926 1925 1924 1923 1922 1921 1920 # VS 2019
   1916 1915 1914 1913 1912 1911 1910 # VS 2017
   1900 # VS 2015
@@ -126,7 +126,7 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1940))     # VS 2022
+  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1941))     # VS 2022
     set(vs_version "17")
   elseif((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
     set(vs_version "16")

--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -104,7 +104,7 @@ cmake_minimum_required(VERSION 3.5)
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
 set(_Vcvars_SUPPORTED_MSVC_VERSIONS
-  1940 1939 1938 1937 1936 1935 1934 1933 1932 1931 1930 # VS 2022
+  1949 1948 1947 1946 1945 1944 1943 1942 1941 1940 1939 1938 1937 1936 1935 1934 1933 1932 1931 1930 # VS 2022
   1929 1928 1927 1926 1925 1924 1923 1922 1921 1920 # VS 2019
   1916 1915 1914 1913 1912 1911 1910 # VS 2017
   1900 # VS 2015
@@ -126,7 +126,7 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1941))     # VS 2022
+  if((msvc_version GREATER_EQUAL 1930) AND (msvc_version LESS 1950))     # VS 2022
     set(vs_version "17")
   elseif((msvc_version GREATER_EQUAL 1920) AND (msvc_version LESS 1930)) # VS 2019
     set(vs_version "16")

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For reference, the associated merge request is https://gitlab.kitware.com/cmake/
 
 ## Notes
 
-* Anticipate future release of VS 2022 listing MSVC_VERSION up to 1940 as being valid version numbers. 
+* Anticipate future release of VS 2022 listing MSVC_VERSION up to 1949 as being valid version numbers. 
 
 * There is no support for looking up `Microsoft Visual C++ Compiler for Python 2.7`
 
@@ -25,7 +25,7 @@ For reference, the associated merge request is https://gitlab.kitware.com/cmake/
 
 * Update `_Vcvars_SUPPORTED_MSVC_VERSIONS` anticipating future VS 2022 releases
 
-* Fix typo in commentdd
+* Fix typo in comments
 
 ### v1.5
 


### PR DESCRIPTION
Since visual studio updated toolset to 1440 version number.

See https://devblogs.microsoft.com/cppblog/msvc-toolset-minor-version-number-14-40-in-vs-2022-v17-10/ And https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-notes#17.10.0