### PR TITLE
Add initial support for Visual Studio 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
         path: src
 
     - name: Setup cmake
-      uses: jwlawson/actions-setup-cmake@v2.0.2
+      uses: lukka/get-cmake@4169813123dd72674c1697fc8f2554818db4c92b # v4.2.0-rc1
       with:
-        cmake-version: ${{ matrix.cmake-version }}
+        cmakeVersion: ${{ matrix.cmake-version }}
 
     - name: Configure
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 3
       matrix:
         os: [windows-latest]
-        cmake-version: [3.31.8]
+        cmake-version: [4.2.0]
         include:
           - os: windows-latest
             cmake-generator: "Visual Studio 17 2022"
@@ -36,7 +36,7 @@ jobs:
         path: src
 
     - name: Setup cmake
-      uses: lukka/get-cmake@4169813123dd72674c1697fc8f2554818db4c92b # v4.2.0-rc1
+      uses: lukka/get-cmake@bb2faa721a800324b726fec00f7c1ff7641964d1 # v4.2.0
       with:
         cmakeVersion: ${{ matrix.cmake-version }}
 

--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -177,6 +177,7 @@ to their associated toolset or Visual Studio major release:
 
   Example mappings:
 
+  - ``Vcvars_TOOLSET_145_MSVC_VERSIONS`` — MSVC versions associated with toolset ``v145`` (Visual Studio 2026)
   - ``Vcvars_TOOLSET_143_MSVC_VERSIONS`` — MSVC versions associated with toolset ``v143`` (Visual Studio 2022)
   - ``Vcvars_TOOLSET_142_MSVC_VERSIONS`` — MSVC versions associated with toolset ``v142`` (Visual Studio 2019)
   - ``Vcvars_TOOLSET_141_MSVC_VERSIONS`` — MSVC versions associated with toolset ``v141`` (Visual Studio 2017)
@@ -196,6 +197,7 @@ to their associated toolset or Visual Studio major release:
 
   Example aliases:
 
+  - ``Vcvars_VS18_MSVC_VERSIONS`` — aliases ``Vcvars_TOOLSET_145_MSVC_VERSIONS`` (Visual Studio 2026)
   - ``Vcvars_VS17_MSVC_VERSIONS`` — aliases ``Vcvars_TOOLSET_143_MSVC_VERSIONS`` (Visual Studio 2022)
   - ``Vcvars_VS16_MSVC_VERSIONS`` — aliases ``Vcvars_TOOLSET_142_MSVC_VERSIONS`` (Visual Studio 2019)
   - ``Vcvars_VS15_MSVC_VERSIONS`` — aliases ``Vcvars_TOOLSET_141_MSVC_VERSIONS`` (Visual Studio 2017)
@@ -222,6 +224,9 @@ cmake_minimum_required(VERSION 3.20.6...3.22.6 FATAL_ERROR)
 
 # See https://github.com/Kitware/CMake/blob/v4.0.3/Modules/Platform/Windows-MSVC.cmake#L72-L101
 
+set(Vcvars_TOOLSET_145_MSVC_VERSIONS # VS 2026
+  1959 1958 1957 1956 1955 1954 1953 1952 1951 1950
+  )
 set(Vcvars_TOOLSET_143_MSVC_VERSIONS # VS 2022
   1949 1948 1947 1946 1945 1944 1943 1942 1941 1940
   1939 1938 1937 1936 1935 1934 1933 1932 1931 1930
@@ -244,6 +249,7 @@ set(Vcvars_TOOLSET_60_MSVC_VERSIONS 1200) # VS 6.0
 
 # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
 # and https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9271
+set(Vcvars_VS18_MSVC_VERSIONS ${Vcvars_TOOLSET_145_MSVC_VERSIONS}) # VS 2026
 set(Vcvars_VS17_MSVC_VERSIONS ${Vcvars_TOOLSET_143_MSVC_VERSIONS}) # VS 2022
 set(Vcvars_VS16_MSVC_VERSIONS ${Vcvars_TOOLSET_142_MSVC_VERSIONS}) # VS 2019
 set(Vcvars_VS15_MSVC_VERSIONS ${Vcvars_TOOLSET_141_MSVC_VERSIONS}) # VS 2017
@@ -261,6 +267,7 @@ set(Vcvars_VS6_MSVC_VERSIONS ${Vcvars_TOOLSET_60_MSVC_VERSIONS}) # VS 6.0
 set(_Vcvars_MSVC_ARCH_REGEX "^(32|64)$")
 set(_Vcvars_MSVC_VERSION_REGEX "^[0-9][0-9][0-9][0-9]$")
 set(_Vcvars_SUPPORTED_MSVC_VERSIONS
+  ${Vcvars_TOOLSET_145_MSVC_VERSIONS} # VS 2026
   ${Vcvars_TOOLSET_143_MSVC_VERSIONS} # VS 2022
   ${Vcvars_TOOLSET_142_MSVC_VERSIONS} # VS 2019
   ${Vcvars_TOOLSET_141_MSVC_VERSIONS} # VS 2017
@@ -296,7 +303,9 @@ function(Vcvars_ConvertMsvcVersionToVsVersion msvc_version output_var)
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
   # See https://en.wikipedia.org/wiki/Microsoft_Visual_C%2B%2B#Internal_version_numbering
-  if(msvc_version IN_LIST Vcvars_VS17_MSVC_VERSIONS) # VS 2022
+  if(msvc_version IN_LIST Vcvars_VS18_MSVC_VERSIONS) # VS 2026
+    set(vs_version "18")
+  elseif(msvc_version IN_LIST Vcvars_VS17_MSVC_VERSIONS) # VS 2022
     set(vs_version "17")
   elseif(msvc_version IN_LIST Vcvars_VS16_MSVC_VERSIONS) # VS 2019
     set(vs_version "16")
@@ -330,7 +339,9 @@ function(Vcvars_ConvertMsvcVersionToVcToolsetVersion msvc_version output_var)
   if(NOT msvc_version MATCHES ${_Vcvars_MSVC_VERSION_REGEX})
     message(FATAL_ERROR "msvc_version is expected to match `${_Vcvars_MSVC_VERSION_REGEX}`")
   endif()
-  if(msvc_version IN_LIST Vcvars_TOOLSET_143_MSVC_VERSIONS) # VS 2022
+  if(msvc_version IN_LIST Vcvars_TOOLSET_145_MSVC_VERSIONS) # VS 2026
+    set(vc_toolset_version "14.5")
+  elseif(msvc_version IN_LIST Vcvars_TOOLSET_143_MSVC_VERSIONS) # VS 2022
     set(vc_toolset_version "14.3")
   elseif(msvc_version IN_LIST Vcvars_TOOLSET_142_MSVC_VERSIONS) # VS 2019
     set(vc_toolset_version "14.2")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -149,6 +149,8 @@ check_function_defined("Vcvars_ConvertMsvcVersionToVcToolsetVersion")
 check_function_defined("Vcvars_GetVisualStudioPaths")
 check_function_defined("Vcvars_FindFirstValidMsvcVersion")
 
+# VS 2026
+check_var_equals(Vcvars_TOOLSET_145_MSVC_VERSIONS "1959;1958;1957;1956;1955;1954;1953;1952;1951;1950")
 # VS 2022
 check_var_equals(Vcvars_TOOLSET_143_MSVC_VERSIONS "1949;1948;1947;1946;1945;1944;1943;1942;1941;1940;1939;1938;1937;1936;1935;1934;1933;1932;1931;1930")
 # VS 2019
@@ -165,6 +167,7 @@ check_var_equals(Vcvars_TOOLSET_71_MSVC_VERSIONS "1310") # VS 2003
 check_var_equals(Vcvars_TOOLSET_70_MSVC_VERSIONS "1300") # VS 2002
 check_var_equals(Vcvars_TOOLSET_60_MSVC_VERSIONS "1200") # VS 6.0
 
+check_var_equals(Vcvars_VS18_MSVC_VERSIONS "${Vcvars_TOOLSET_145_MSVC_VERSIONS}") # VS 2026
 check_var_equals(Vcvars_VS17_MSVC_VERSIONS "${Vcvars_TOOLSET_143_MSVC_VERSIONS}") # VS 2022
 check_var_equals(Vcvars_VS16_MSVC_VERSIONS "${Vcvars_TOOLSET_142_MSVC_VERSIONS}") # VS 2019
 check_var_equals(Vcvars_VS15_MSVC_VERSIONS "${Vcvars_TOOLSET_141_MSVC_VERSIONS}") # VS 2017
@@ -190,6 +193,7 @@ function(check_msvc_version_to_vs_version_convert msvc_versions_var expected_vs_
   endforeach()
 endfunction()
 
+check_msvc_version_to_vs_version_convert(Vcvars_VS18_MSVC_VERSIONS "18")
 check_msvc_version_to_vs_version_convert(Vcvars_VS17_MSVC_VERSIONS "17")
 check_msvc_version_to_vs_version_convert(Vcvars_VS16_MSVC_VERSIONS "16")
 check_msvc_version_to_vs_version_convert(Vcvars_VS15_MSVC_VERSIONS "15")
@@ -215,6 +219,7 @@ function(check_msvc_version_to_vc_toolset_version_convert msvc_versions_var expe
   endforeach()
 endfunction()
 
+check_msvc_version_to_vc_toolset_version_convert(Vcvars_VS18_MSVC_VERSIONS "14.5")
 check_msvc_version_to_vc_toolset_version_convert(Vcvars_VS17_MSVC_VERSIONS "14.3")
 check_msvc_version_to_vc_toolset_version_convert(Vcvars_VS16_MSVC_VERSIONS "14.2")
 check_msvc_version_to_vc_toolset_version_convert(Vcvars_VS15_MSVC_VERSIONS "14.1")


### PR DESCRIPTION
See https://devblogs.microsoft.com/visualstudio/visual-studio-2026-insiders-is-here/

https://devblogs.microsoft.com/cppblog/c-language-updates-in-msvc-build-tools-v14-50/

Visual Studio 2026 in GitHub hosted runners progress at `https://github.com/actions/runner-images/issues/13035`