### PR TITLE
Fix searching for VS2026 in older cmake version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
         cmake-version: [4.2.0]
         include:
           - os: windows-latest
-            cmake-generator: "Visual Studio 17 2022"
+            cmake-generator: "Visual Studio 18 2026"
             expected-msvc-arch: 64
-            expected-msvc-version: 1949 # Visual Studio 17 2022
+            expected-msvc-version: 1959 # Visual Studio 18 2026
             expected-batch-filename: "vcvars64.bat"
             expected-wrapper-filename: "vcvars64_wrapper.bat"
-            expected-platform-toolset-version: "14.3"
+            expected-platform-toolset-version: "14.5"
 
     name: Tests on ${{ matrix.os }}
     steps:

--- a/FindVcvars.cmake
+++ b/FindVcvars.cmake
@@ -390,7 +390,10 @@ function(Vcvars_GetVisualStudioPaths msvc_version msvc_arch output_var)
     string(REGEX REPLACE "^([0-9]+)\.[0-9]+$" "\\1" vs_installer_version ${vs_version})
     # Probe the matching VS version and any newer versions, since a newer VS installation
     # (e.g., VS 2026) may host older toolsets (e.g., v143) as optional components.
-    set(_known_vs_major_versions 15 16 17 18)
+    set(_known_vs_major_versions 15 16 17)  # VS 2017, 2019, 2022
+    if(CMAKE_VERSION VERSION_GREATER_EQUAL "4.2.0")
+      list(APPEND _known_vs_major_versions 18) # VS 2026
+    endif()
     foreach(_probe_vs IN LISTS _known_vs_major_versions)
       if(_probe_vs LESS vs_installer_version)
         continue()


### PR DESCRIPTION
This is a follow-up to https://github.com/scikit-build/cmake-FindVcvars/commit/f71cb982bf1905b1964080c88c7f36efea04561a.

This adds a guard to look in a VS2026 install path for VcVars only if the CMake version supports it.